### PR TITLE
Updated the ldap3 integration

### DIFF
--- a/hug_authentication_ldap/authentication.py
+++ b/hug_authentication_ldap/authentication.py
@@ -32,7 +32,7 @@ def server(url, get_info=ldap3.ALL, **kwargs):
     return ldap3.Server(url, get_info=get_info, **kwargs)
 
 
-def verify(server_instance, user_template="uid={user_name},ou=people", authentication=ldap3.AUTH_SIMPLE, auto_bind=True,
+def verify(server_instance, user_template="uid={user_name},ou=people", authentication=ldap3.SIMPLE, auto_bind=True,
             **kwargs):
     """Returns an authentication verification callback that enforces ldap authentication passing in the
        user_template with the passed in user overriding any in-string placement of {user_name}


### PR DESCRIPTION
Python's ldap3 AUTH_SIMPLE changed from AUTH_SIMPLE to just SIMPLE as seen here: http://ldap3.readthedocs.io/changelog.html