### PR TITLE
Improvements to PyPI packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ dist
 # IDE Files
 atlassian-ide-plugin.xml
 .idea/
+.vscode/
 *.swp
 *.kate-swp
 .ropeproject/

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,6 @@ universal = 1
 [flake8]
 ignore = F401,F403,E502,E123,E127,E128,E303,E713,E111,E241,E302,E121,E261,W391
 max-line-length = 120
+
+[metadata]
+license_file = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -75,16 +75,17 @@ class PyTest(TestCommand):
 
 cmdclass['test'] = PyTest
 
-try:
-   import pypandoc
-   readme = pypandoc.convert('README.md', 'rst')
-except (IOError, ImportError, OSError, RuntimeError):
-   readme = ''
+
+with open('README.md', encoding='utf-8') as f:  # Loads in the README for PyPI
+    long_description = f.read()
+
 
 setup(name='hug_authentication_ldap',
       version='1.0.3',
       description='LDAP based authentication support for hug',
-      long_description=readme,
+      long_description=long_description,
+      # PEP 566, the new PyPI, and setuptools>=38.6.0 make markdown possible
+      long_description_content_type='text/markdown',
       author='Timothy Crosley',
       author_email='timothy.crosley@gmail.com',
       url='https://github.com/timothycrosley/hug_authentication_ldap',


### PR DESCRIPTION
The new version of PyPI and Warehouse added support for PEP 566,
which adds the option "long_description_content_type" to specify the
format of the long description used on the PyPI page. This removes
the need to convert it to RST using pypandoc, which (for this package
at least) was not formatting correctly.

Summary:

Remove need to convert README to RST
Ensure LICENSE gets included in the package
I'm opening similar PRs (well, almost identical) in hug_explainable and hug_yaml as well. Apologies for the notification spam!